### PR TITLE
[Source Map] fix source map for build & demo

### DIFF
--- a/demo/default/app.js
+++ b/demo/default/app.js
@@ -2,8 +2,7 @@ import 'bootstrap/dist/css/bootstrap.css'; // eslint-disable-line
 import React, { Component } from 'react';
 import _ from 'underscore';
 
-import ReactProjectionGrid, { sortable, bootstrapProjection } from 'ReactProjectionGrid'; // eslint-disable-line
-
+import ReactProjectionGrid, { sortable, bootstrapProjection } from 'react-projection-grid'; // eslint-disable-line
 import people from './people.json';
 
 export default class App extends Component {

--- a/demo/default/webpack.config.js
+++ b/demo/default/webpack.config.js
@@ -19,6 +19,11 @@ module.exports = {
   },
   module: {
     rules: [
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
       { test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/ },
       { test: /\.js$/, loader: 'eslint-loader', exclude: [/node_modules/, /dist/] },
       {
@@ -47,8 +52,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      ReactProjectionGrid: '../../dist/index',
-      'projection-grid-core': 'projection-grid-core/src/index',
+      'react-projection-grid': '../../dist/index',
     },
   },
   plugins: [

--- a/demo/default/webpack.config.js
+++ b/demo/default/webpack.config.js
@@ -57,9 +57,6 @@ module.exports = {
       jQuery: 'jquery',
       'window.jQuery': 'jquery',
       Popper: ['popper.js', 'default'],
-    }),
-    new webpack.SourceMapDevToolPlugin({
-      filename: '[name].js.map',
     })
   ]
 };

--- a/package.json
+++ b/package.json
@@ -59,24 +59,19 @@
     "react-test-renderer": "^16.1.0",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.19.0",
+    "underscore": "^1.8.3",
     "url-loader": "^0.6.2",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.3"
   },
   "dependencies": {
-    "backbone": "^1.3.3",
-    "backbone-virtualized-listview": "^0.6.7",
-    "bluebird": "^3.5.1",
-    "fast-binary-indexed-tree": "^1.0.1",
-    "js-data": "^3.0.1",
-    "jsx-to-html": "^1.1.0",
-    "knockout": "^3.4.2",
-    "projection-grid": "^0.1.7",
     "projection-grid-core": "0.0.8",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-hot-loader": "^3.1.1",
+    "react-hot-loader": "^3.1.1"
+  },
+  "peerDependencies": {
     "underscore": "^1.8.3"
   },
   "jest": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,8 @@ module.exports = {
     ],
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
+    }),
   ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,12 +456,6 @@ babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
-babel-plugin-jsx@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jsx/-/babel-plugin-jsx-1.2.0.tgz#9c926e5ff421d376123ccbc103dfba5560d171e3"
-  dependencies:
-    esutils "^2.0.2"
-
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
@@ -803,16 +797,6 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
-backbone-virtualized-listview@^0.6.7:
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/backbone-virtualized-listview/-/backbone-virtualized-listview-0.6.7.tgz#77572dae3f683cf1b67397bc2fc028bba6eb263c"
-
-backbone@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.3.3.tgz#4cc80ea7cb1631ac474889ce40f2f8bc683b2999"
-  dependencies:
-    underscore ">=1.8.3"
-
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -849,7 +833,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.5.1, bluebird@~3.5.0:
+bluebird@~3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -1757,10 +1741,6 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-empty-tags@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/empty-tags/-/empty-tags-1.0.0.tgz#27fa80b8f07290f9f4be735a9b5b8d3dd5651fb3"
-
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
@@ -1912,7 +1892,7 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-escape-html@^1.0.2, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
@@ -2234,10 +2214,6 @@ extglob@^0.3.1:
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-fast-binary-indexed-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fast-binary-indexed-tree/-/fast-binary-indexed-tree-1.0.1.tgz#1e327aa63dc1d2dc7ff65d654b2f363b42bd778f"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -2708,10 +2684,6 @@ html-encoding-sniffer@^1.0.1:
 html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
-
-html-tags@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.2.0.tgz#c78de65b5663aa597989dd2b7ab49200d7e4db98"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -3381,10 +3353,6 @@ js-base64@^2.1.9:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.3.2.tgz#a79a923666372b580f8e27f51845c6f7e8fbfbaf"
 
-js-data@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-data/-/js-data-3.0.1.tgz#84d0c5e3031b7fd645b25db4c6e0aab8911df202"
-
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -3517,23 +3485,6 @@ jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
-jsx-runtime@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/jsx-runtime/-/jsx-runtime-1.2.0.tgz#3bae0dad50ec30541bb5b0420b104856694350cb"
-  dependencies:
-    object-assign "^3.0.0"
-
-jsx-to-html@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsx-to-html/-/jsx-to-html-1.1.0.tgz#054c90acf8dcd83f1520332267caf65fc8e92f41"
-  dependencies:
-    babel-plugin-jsx "^1.1.0"
-    empty-tags "^1.0.0"
-    escape-html "^1.0.2"
-    html-tags "^1.1.1"
-    jsx-runtime "^1.1.0"
-    svg-tags "^1.0.0"
-
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
@@ -3555,10 +3506,6 @@ klaw@~2.0.0:
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.0.0.tgz#59c128e0dc5ce410201151194eeb9cbf858650f6"
   dependencies:
     graceful-fs "^4.1.9"
-
-knockout@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/knockout/-/knockout-3.4.2.tgz#e87958de77ad1e936f7ce645bab8b5d7c456d937"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -4040,10 +3987,6 @@ number-is-nan@^1.0.0:
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-
-object-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -4662,10 +4605,6 @@ progress@^2.0.0:
 projection-grid-core@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/projection-grid-core/-/projection-grid-core-0.0.8.tgz#e68b7d3d3ac8bf3f7a6c88efca697c12e47f9398"
-
-projection-grid@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/projection-grid/-/projection-grid-0.1.7.tgz#9dd9efb355ba3f987b20505ccbcb2e05ee9a6626"
 
 promise@^7.1.1:
   version "7.3.1"
@@ -5561,10 +5500,6 @@ supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
   dependencies:
     has-flag "^2.0.0"
 
-svg-tags@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
-
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
@@ -5767,7 +5702,7 @@ underscore@1.6.0, underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
-underscore@>=1.8.3, underscore@^1.8.3, underscore@~1.8.3:
+underscore@^1.8.3, underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 


### PR DESCRIPTION
1. For build, `webpack.config.js` is fixed by adding option for `UglifyJsPlugin` to generate source map for `dist/index.js`.
2. For demo, `demo/default/webpack.config.js` is fixed by adding `source-map-loader` and remove the mal configs. Now we can see
   * demo code source in `webpack://.`
   * `react-projection-grid` source in `webpack://webpack://src`
   * `projection-grid-code` source in `webpack://webpack://webpack:src`
![image](https://user-images.githubusercontent.com/5836327/33466151-1e12f9ca-d687-11e7-9230-71b9dd7a8b41.png)
